### PR TITLE
pass through existing entries and use them for training

### DIFF
--- a/smart_importer/machinelearning_helpers.py
+++ b/smart_importer/machinelearning_helpers.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Union, Optional
 
 import numpy as np
+from typing import Tuple
 from beancount import loader
 from beancount.core.data import Transaction, Posting, TxnPosting, filter_txns
 from beancount.ingest.cache import _FileMemo
@@ -14,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 def load_training_data(training_data: Union[_FileMemo, List[Transaction], str],
-                       filter_training_data_by_account: str = None) -> List[Transaction]:
+                       filter_training_data_by_account: str = None,
+                       existing_entries: List[Tuple] = None) -> List[Transaction]:
     '''
     Loads training data
     :param training_data: The training data that shall be loaded.
@@ -23,9 +25,13 @@ def load_training_data(training_data: Union[_FileMemo, List[Transaction], str],
         or a list of beancount entries
     :param filter_training_data_by_account: Optional filter for the training data.
         If provided, the training data is filtered to only include transactions that involve the specified account.
+    :param existing_entries: Optional existing entries to use instead of explicit training_data
     :return: Returns a list of beancount entries.
     '''
-    if isinstance(training_data, _FileMemo):
+    if not training_data and existing_entries:
+        logger.debug("Using existing entries for training data")
+        training_data = list(filter_txns(existing_entries))
+    elif isinstance(training_data, _FileMemo):
         logger.debug(f"Reading training data from _FileMemo \"{training_data.name}\"...")
         training_data, errors, _ = loader.load_file(training_data.name)
         assert not errors

--- a/smart_importer/predict_payees.py
+++ b/smart_importer/predict_payees.py
@@ -41,7 +41,7 @@ class PredictPayees:
     # see http://scottlobdell.me/2015/04/decorators-arguments-python/
 
     def __init__(self, *,
-                 training_data: Union[_FileMemo, List[Transaction], str],
+                 training_data: Union[_FileMemo, List[Transaction], str] = None,
                  filter_training_data_by_account: str = None,
                  predict_payees: bool = True,
                  overwrite_existing_payees=False,
@@ -66,10 +66,15 @@ class PredictPayees:
             :return: list of beancount transactions
             """
 
+            existing_entries = None
+            if 'existing_entries' in kwargs:
+                existing_entries = kwargs['existing_entries']
+
             # load training data
             self.training_data = ml.load_training_data(
                 self.training_data,
-                filter_training_data_by_account=self.filter_training_data_by_account)
+                filter_training_data_by_account=self.filter_training_data_by_account,
+                existing_entries=existing_entries)
 
             # train the machine learning model
             self._trained = False

--- a/smart_importer/predict_postings.py
+++ b/smart_importer/predict_postings.py
@@ -41,7 +41,7 @@ class PredictPostings:
     # see http://scottlobdell.me/2015/04/decorators-arguments-python/
 
     def __init__(self, *,
-                 training_data: Union[_FileMemo, List[Transaction], str],
+                 training_data: Union[_FileMemo, List[Transaction], str] = None,
                  filter_training_data_by_account: str = None,
                  predict_second_posting: bool = True,
                  suggest_accounts: bool = True):
@@ -63,11 +63,16 @@ class PredictPostings:
             :param **kwargs: original keyword arguments to be passed
             :return: list of beancount transactions
             """
+            existing_entries = None
+            if 'existing_entries' in kwargs:
+                existing_entries = kwargs['existing_entries']
+
 
             # load training data
             self.training_data = ml.load_training_data(
                 self.training_data,
-                filter_training_data_by_account=self.filter_training_data_by_account)
+                filter_training_data_by_account=self.filter_training_data_by_account,
+                existing_entries=existing_entries)
 
             # convert training data to a list of TxnPostings
             self.converted_training_data = [TxnPosting(t, p) for t in self.training_data for p in t.postings

--- a/smart_importer/tests/machinelearning_helpers_test.py
+++ b/smart_importer/tests/machinelearning_helpers_test.py
@@ -61,6 +61,15 @@ class MachinelearningTest(unittest.TestCase):
         )
         self.assertEqual(1, len(list(test_data)))
 
+    def test_load_training_data_use_existing(self):
+        logger.info("Running Test Case: {id}".format(id=self.id().split('.')[-1]))
+        existing_entries = self.test_data
+        actual = ml.load_training_data(
+            training_data=None,
+            existing_entries=existing_entries
+        )
+        self.assertEqual(existing_entries, actual)
+
     def test_transaction_involves_account(self):
         logger.info("Running Test Case: {id}".format(id=self.id().split('.')[-1]))
         self.assertTrue(ml.transaction_involves_account(self.test_transaction, None))


### PR DESCRIPTION
Allow not to specify specific training_data and use the existing_entries instead for training, fixes #8 